### PR TITLE
Update load_prepared_dataset_in_dataloaders.py

### DIFF
--- a/PrepareAndLoadData/load_prepared_dataset_in_dataloaders.py
+++ b/PrepareAndLoadData/load_prepared_dataset_in_dataloaders.py
@@ -129,129 +129,76 @@ def load_dataloaders_for_regression(path, feature, number_of_cycle=4, batch_size
             return participants_dataloaders_train, participants_dataloaders_validation
 
 
-def get_dataloader_for_training_no_TL(examples_datasets, labels_datasets, number_of_cycle, validations_cycles=None,
-                                      batch_size=128, drop_last=True, shuffle=True):
-    X, Y, X_valid, Y_valid = [], [], [], []
-    for participant_examples, participant_labels in zip(examples_datasets, labels_datasets):
-        for cycle in range(number_of_cycle):
-            if validations_cycles is None:
+def get_dataloader(examples_datasets, labels_datasets, cycle_used, batch_size=128,
+                   drop_last=True, shuffle=True, aggre=False):
+    # cycle_used is a list for specifying which cycles are used
+    # aggre is used to specify if data is saved by participants (=False) or not (=True)
+    dataloaders = []
+    
+    if aggre:
+        X, Y = [], []
+        for participant_examples, participant_labels in zip(examples_datasets, labels_datasets):
+            for cycle in cycle_used:
                 X.extend(participant_examples[cycle])
                 Y.extend(participant_labels[cycle])
-            else:
-                if cycle < validations_cycles:
-                    X.extend(participant_examples[cycle])
-                    Y.extend(participant_labels[cycle])
-                else:
-                    X_valid.extend(participant_examples[cycle])
-                    Y_valid.extend(participant_labels[cycle])
-    X = np.expand_dims(X, axis=1)
-    train = TensorDataset(torch.from_numpy(np.array(X, dtype=np.float32)),
-                          torch.from_numpy(np.array(Y, dtype=np.int64)))
-    examplesloader = torch.utils.data.DataLoader(train, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last)
-
-    if validations_cycles is not None:
-        X_valid = np.expand_dims(X_valid, axis=1)
-        validation = TensorDataset(torch.from_numpy(np.array(X_valid, dtype=np.float32)),
-                                   torch.from_numpy(np.array(Y_valid, dtype=np.int64)))
-        validationloader = torch.utils.data.DataLoader(validation, batch_size=batch_size, shuffle=shuffle,
-                                                       drop_last=drop_last)
-        return examplesloader, validationloader
-    else:
-        return examplesloader
-
-
-def get_dataloader(examples_datasets, labels_datasets, number_of_cycle, validations_cycles=None, batch_size=128,
-                   drop_last=True, shuffle=True):
-    participants_dataloaders = []
-    participants_dataloaders_validation = []
-
-    for participant_examples, participant_labels in zip(examples_datasets, labels_datasets):
-        X, Y, X_valid, Y_valid = [], [], [], []
-
-        for cycle in range(number_of_cycle):
-            if validations_cycles is None:
-                X.extend(participant_examples[cycle])
-                Y.extend(participant_labels[cycle])
-            else:
-                if cycle < validations_cycles:
-                    X.extend(participant_examples[cycle])
-                    Y.extend(participant_labels[cycle])
-                else:
-                    X_valid.extend(participant_examples[cycle])
-                    Y_valid.extend(participant_labels[cycle])
-        X = np.expand_dims(X, axis=1)
-        train = TensorDataset(torch.from_numpy(np.array(X, dtype=np.float32)),
+        X = np.expand_dims(X, axis=1)  # For data aggregation
+        data = TensorDataset(torch.from_numpy(np.array(X, dtype=np.float32)),
                               torch.from_numpy(np.array(Y, dtype=np.int64)))
-        examplesloader = torch.utils.data.DataLoader(train, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last)
-        participants_dataloaders.append(examplesloader)
-
-        if validations_cycles is not None:
-            X_valid = np.expand_dims(X_valid, axis=1)
-            validation = TensorDataset(torch.from_numpy(np.array(X_valid, dtype=np.float32)),
-                                       torch.from_numpy(np.array(Y_valid, dtype=np.int64)))
-            validationloader = torch.utils.data.DataLoader(validation, batch_size=len(X_valid), shuffle=shuffle,
-                                                           drop_last=drop_last)
-            participants_dataloaders_validation.append(validationloader)
-
-    if validations_cycles is None:
-        return participants_dataloaders
+        dataloaders = torch.utils.data.DataLoader(data, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last)
     else:
-        return participants_dataloaders, participants_dataloaders_validation
+        for participant_examples, participant_labels in zip(examples_datasets, labels_datasets):
+            X, Y = [], []
+            for cycle in cycle_used:
+                X.extend(participant_examples[cycle])
+                Y.extend(participant_labels[cycle])
+            X = np.expand_dims(X, axis=1)  # Save each dataset by participant index
+            data = TensorDataset(torch.from_numpy(np.array(X, dtype=np.float32)),
+                              torch.from_numpy(np.array(Y, dtype=np.int64)))
+            examplesloader = torch.utils.data.DataLoader(data, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last)
+            dataloaders.append(examplesloader)
+    return dataloaders
 
-def load_dataloader_for_training_without_TL(path, number_of_cycle=4, batch_size=128, validation_cycle=3, drop_last=True,
-                                            shuffle=True):
 
-    datasets_train = np.load(path + "/RAW_3DC_train.npy")
-    'Get training dataset'
-    examples_datasets_train, labels_datasets_train = datasets_train
-    if validation_cycle is None:
-        participants_dataloaders_train = get_dataloader_for_training_no_TL(examples_datasets_train,
-                                                                           labels_datasets_train, number_of_cycle,
-                                                                           validations_cycles=validation_cycle,
-                                                                           batch_size=batch_size, drop_last=drop_last,
-                                                                           shuffle=shuffle)
-        return participants_dataloaders_train
-    else:
-        participants_dataloaders_train, participants_dataloaders_validation = get_dataloader_for_training_no_TL(
-            examples_datasets_train, labels_datasets_train, number_of_cycle, validations_cycles=validation_cycle,
-            batch_size=batch_size, drop_last=drop_last, shuffle=shuffle)
-        return participants_dataloaders_train, participants_dataloaders_validation
-
-def load_dataloaders(path, number_of_cycle=4, batch_size=128, validation_cycle=3, get_test_set=True, drop_last=True,
-                     shuffle=True):
+def load_dataloaders(path, number_of_cycle=4, batch_size=128, valid_cycle_num=1, get_test_set=True, drop_last=True, aggre_required=False):
+    # valid_cycle_num: to specify how many cylcles are needed for validation
+    
+    #  These comments can be delected later if the code modification is approved 
+    #  aggre_requires = False is the same as the original function 'loader_dataloaders'
+    #  aggre_requires = False is the same as the original function 'loader_dataloaders_for_training_without_TL'
+    #  valid_cycle_num = 1 is the same as the original variable 'validation_cycle'=3 here
+    #  The variable shuffle can be removed since it is usually set to true for training and validation, while false for testing 
     participants_dataloaders_test = []
-    'Get testing dataset'
     if get_test_set:
+        'Get testing dataset'
         datasets_test = np.load(path + "/RAW_3DC_test.npy")
         examples_datasets_test, labels_datasets_test = datasets_test
-
-        participants_dataloaders_test = get_dataloader(examples_datasets_test, labels_datasets_test, number_of_cycle,
-                                                       validations_cycles=None, batch_size=batch_size,
-                                                       drop_last=drop_last, shuffle=False)
+        test_cycles = list(range(number_of_cycle))
+        participants_dataloaders_test = get_dataloader(examples_datasets_test, labels_datasets_test, test_cycles,
+                                                       batch_size=batch_size, drop_last=drop_last, shuffle=False,
+                                                       aggre=aggre_required)
     'Get training dataset'
     datasets_train = np.load(path + "/RAW_3DC_train.npy")
     examples_datasets_train, labels_datasets_train = datasets_train
-    if validation_cycle is None:
-        participants_dataloaders_train = get_dataloader(examples_datasets_train, labels_datasets_train, number_of_cycle,
-                                                        validations_cycles=validation_cycle, batch_size=batch_size,
-                                                        drop_last=drop_last, shuffle=shuffle)
-        if get_test_set:
-            return participants_dataloaders_train, participants_dataloaders_test
-        else:
-            return participants_dataloaders_train
-    else:
-        participants_dataloaders_train, participants_dataloaders_validation = get_dataloader(examples_datasets_train,
-                                                                                             labels_datasets_train,
-                                                                                             number_of_cycle,
-                                                                                             validations_cycles=
-                                                                                             validation_cycle,
-                                                                                             batch_size=batch_size,
-                                                                                             drop_last=drop_last,
-                                                                                             shuffle=shuffle)
-        if get_test_set:
-            return participants_dataloaders_train, participants_dataloaders_validation, participants_dataloaders_test
-        else:
-            return participants_dataloaders_train, participants_dataloaders_validation
+    train_cycles = list(range(number_of_cycle))
+    valid_cycles = []
+    for _ in range(validation_cycle):
+        valid_cycles.append(train_cycles.pop())
+    
+    #  for example, if number_of_cycle=4 and valid_cycle_num=1,
+    #  train_cycles = [0,1,2] and valid_cycles = [3] here
+    
+    participants_dataloaders_train = get_dataloader(examples_datasets_train, labels_datasets_train, train_cycles,
+                                                    batch_size=batch_size, drop_last=drop_last, shuffle=True,
+                                                    aggre=aggre_required)
+    participants_dataloaders_valid = []
+    if valid_cycle_num !=0:
+        'Get validation dataset'
+        participants_dataloaders_valid = get_dataloader(examples_datasets_train, labels_datasets_train,
+                                                        valid_cycles, batch_size=batch_size, 
+                                                        drop_last=drop_last, shuffle=True,
+                                                        aggre=aggre_required)
+    
+    return participants_dataloaders_train, participants_dataloaders_validation, participants_dataloaders_test
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To improve the code readability and reduce the code redundancy.

1. It is found 'get_dataloader' is a key function here, which has been used a lot, and the difference between the function 'load_dataloaders' and 'load_dataloaders_for_training_without_TL' is only the data aggregation. Therefore, the idea is to add the data aggregation function into the 
'get_dataloader'.

2. To improve the way to get validation dataset by allowing the 'get_dataloader' to take cycle_used (a list) as an input.

3. There is no need to use conditions for returning different outputs since you know which one you need when you are using the function.
For example, if you know you only need train and validation sets by setting the 'get_test_set' as False, you could simply use the function 
'load_dataloaders' as follows:
dataloaders_train, dataloaders_validation, _= load_dataloaders()


4. If these modifications seem reasonable to you, similar changes can be done for load_dataloaders_for_regression and get_dataloader_for_regression and
on those files which apply 'load_dataloaders' or 'load_dataloaders_for_training_without_TL', a little modification on the way to call functions needs to be done as well.

Please let me know if there is something unclear or a discussion is needed.